### PR TITLE
fix backspace print

### DIFF
--- a/keyboard.py
+++ b/keyboard.py
@@ -165,6 +165,8 @@ class KeyboardApp(Gtk.Application):
             return
 
         cursor_position: int = self.textarea.get_position()
+        if text == BACKSPACE and cursor_position == 0:
+            return
         if text == BACKSPACE and cursor_position != 0:
             buff: Gtk.EntryBuffer = self.textarea.get_buffer()
             buff.delete_text(cursor_position - 1, 1)


### PR DESCRIPTION
this PR's purpose is to fix unnecassary print "<- Backspace" text on the text box, this only occurs when you click on backspace button when there is no text in the text box, it populates

[Kooha-2024-09-07-21-03-05.webm](https://github.com/user-attachments/assets/635ca597-d7b9-43fc-a586-72036857df5d)

