### PR TITLE
remove ubuntu latest from tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -23,7 +23,7 @@ jobs:
 
     - name: Install GTK deps
       run: |
-        sudo apt install libgirepository-1.0-dev libcairo2-dev -y
+        sudo apt install libgirepository-2.0-dev libcairo2-dev -y
 
     - name: Install uv
       uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
causes some regressions with release pipeline, pinned ubuntu to 24.04